### PR TITLE
fix: allow daily workflow to finish after stagger delay

### DIFF
--- a/.github/workflows/daily-paper-reader.yml
+++ b/.github/workflows/daily-paper-reader.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     env:
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       DEEPSEEK_BASE_URL: ${{ secrets.DEEPSEEK_BASE_URL }}


### PR DESCRIPTION
## 原因

定时任务在正式流水线前会随机等待 0–3599 秒，但 job 的 `timeout-minutes` 仍为 120。最大延时会占掉近一半超时预算，导致后续论文处理尚未结束时被 GitHub Actions 强制取消。

## 修改

- 将 `daily-paper-reader` job 超时从 120 分钟提高到 240 分钟
- 不改变随机错峰范围和流水线逻辑

## 验证

- 该分支基于当前 upstream `main`
- diff 仅包含 `.github/workflows/daily-paper-reader.yml` 的一行超时配置修改
- `git diff --check` 通过